### PR TITLE
Better webpacker support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,6 @@
 FROM ruby:2.4
 ENV BUNDLE_PATH /bundler
+ENV WEBPACKER_DEV_SERVER_HOST webpacker
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y build-essential nodejs yarn

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,23 @@
 source 'https://rubygems.org'
-gem 'rails', '5.1.4'
-gem 'webpacker'
+
+gem 'rails', '~> 5.1.4'
+gem 'puma', '~> 3.7'
+gem 'sass-rails', '~> 5.0'
+gem 'uglifier', '>= 1.3.0'
+gem 'webpacker', '3.0.2'
+gem 'coffee-rails', '~> 4.2'
+gem 'turbolinks', '~> 5'
+gem 'jbuilder', '~> 2.5'
+
+group :development, :test do
+  gem 'byebug'
+  gem 'capybara', '~> 2.13'
+  gem 'selenium-webdriver'
+end
+
+group :development do
+  gem 'web-console', '>= 3.3.0'
+  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'spring'
+  gem 'spring-watcher-listen', '~> 2.0.0'
+end

--- a/README.md
+++ b/README.md
@@ -15,17 +15,7 @@ docker-compose run --no-deps --rm app script/new && rm script/new
 
 ### Then
 
-Go to config/webpacker.yml and change localhost to webpacker to avoid any errors when running in development.
-
-```
-dev_server:
-  host: webpacker
-  port: 3035
-  hmr: false
-  https: false
-```
-
-Now add any other gem you think you need. then run `docker-compose up` (and new gems will automatically be installed)
+Add any other gem you think you need. then run `docker-compose up` (and new gems will automatically be installed)
 
 ### Also
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.0'
+version: '2'
 services:
   db:
     image: mongo
@@ -23,7 +23,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: ./bin/webpack-dev-server --host localhost
+    command: ./script/webpacker
     volumes:
       - .:/workspace
       - bundler:/bundler

--- a/script/webpacker
+++ b/script/webpacker
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yarn check || yarn install
+bundle check || bundle install
+WEBPACKER_DEV_SERVER_HOST=0.0.0.0 bundle exec webpack-dev-server


### PR DESCRIPTION
Webpacker gem was not set to a specific gem which is the reason why #3 was an issue.

- Locked down webpacker to version 3.0.2
- Ensure rails new works correctly
- Simplified setup/configuration